### PR TITLE
Travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: false
+language: node_js
+node_js:
+- '4.2'
+cache:
+  directories:
+  - node_modules
+branches:
+  only:
+  - master
+notifications:
+  email: false
+before_script:
+- npm prune
+script:
+- npm run build
+after_script:
+- bash ./lib/deploy.sh
+env:
+  global:
+  - GH_USER: jbmoelker
+  - GH_REPO: Full-Tilt
+  - secure: UrWYnQMiEs81jq2Mrfl3Zij7w7rvPQBmC4RboDdjm+D+3CoHISV99SBPdHrl3opeQynHDIrDLJ49oUKXHsEsjHi6MEv+HXXtoX+4weUO+M8VyY40yBWQb+bcWxKR9FCDLlRuO77QC3QBImOPd1Ad8HTfLeybCPQsd/G5EQb7x+LoA89nNPgKSkzaL+b0e2X1S4CQ952cqsSWx2VtXUc+ZS/khmKhOT2bG6VBShhOFRYYtpahUP0Ven05X54xdc45wPxPKTSy9e/VUXLb5pv+aqogDPoa33lAdUwVOa87wDyTD6GPIhgvK8cGohT46besv53BAMvDK8MjwWB2NvJJGjG/oCQg7KAmtjnHp87N2Y2ST8CJIW1rore6aAWmZdoy4QuW533aXiA/n+Hrhrsf4P7y6MU2rPlncJSvNUiHX4b7NjKmsLaoUr2yr/jrrnwITvA41KoGX+mzOTPHN4j3J/Xwt+66JsOYRpXfJcqbh2M/W3XOm5vCn+ebWjAii7I3cnM+GuFgrS2lGyc+0JdiuwWj4fz70uMIDQ8rzR5DGGn1pFTKMgWazd55Oiyi6/L7jMia6chTP6LQPuDkOxaVWjmNLAtCkGVcII8QCQiZMkijmnhmn3F1GGkCroUkUWUIgLJDiyScNeG96S1zQdHqBgREDge8FyK/xFN943SnCIE=

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This library also provides all the functions necessary to convert between differ
 * [Installation](#installation)
 * [Usage](#usage)
 * [Documentation](https://github.com/richtr/Full-Tilt/wiki/Full-Tilt-API-Documentation)
+* [Live examples](https://jbmoelker.github.io/Full-Tilt/examples/)
 
 ## Installation ##
 
@@ -85,7 +86,7 @@ Here is a quick example of how to use Full Tilt:
 </script>
 ```
 
-Full [API documentation](https://github.com/richtr/Full-Tilt/wiki/Full-Tilt-API-Documentation) is available on the project wiki and [usage examples](https://github.com/richtr/Full-Tilt/tree/master/examples) are also provided.
+Full [API documentation](https://github.com/richtr/Full-Tilt/wiki/Full-Tilt-API-Documentation) is available on the project wiki and [usage examples](https://jbmoelker.github.io/Full-Tilt/examples/) are also provided.
 
 ## References ##
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
+	<title>Full Tilt examples</title>
+</head>
+<body>
+	<h1><a href="../">Full Tilt</a> examples</h1>
+	<nav>
+		<ul>
+			<li><a href="box2d.html">Floating 2D Box in a Consistent Frame</a></li>
+			<li><a href="compass.html">Compass demo</a></li>
+			<li><a href="data_display.html">Full-Tilt vs Raw DeviceOrientation Event Data Display</a></li>
+			<li><a href="vr_interactive.html">DeviceOrientation three.js interactive test page</a></li>
+			<li><a href="vr_test.html">DeviceOrientation three.js test page</a></li>
+		</ul>
+	</nav>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
+	<title>Full Tilt</title>
+</head>
+<body>
+
+	<nav>
+		<h1>Full Tilt</h1>
+		<ul>
+			<li><a href="examples/">Live examples</a></li>
+			<li><a href="https://github.com/jbmoelker/Full-Tilt#full-tilt">Introduction & Usage</a> (Github Readme)</li>
+			<li><a href="https://github.com/adtile/Full-Tilt/wiki/Full-Tilt-API-Documentation">Documentation</a> (Github Wiki)</li>
+		</ul>
+	</nav>
+
+</body>
+</html>

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e # exit with nonzero exit code if anything fails
+
+if [[ $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST == "false" ]]; then
+
+echo "Starting to update gh-pages\n"
+
+#copy data we're interested in to other place
+mkdir $HOME/temp
+cp -R dist $HOME/temp/dist
+cp -R examples $HOME/temp/examples
+cp index.html $HOME/temp/index.html
+
+#go to home and setup git
+cd $HOME
+git config --global user.email "travis@travis-ci.org"
+git config --global user.name "Travis"
+
+#using token clone gh-pages branch
+git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/${GH_USER}/${GH_REPO}.git gh-pages > /dev/null
+
+#go into directory and copy data we're interested in to that directory
+cd gh-pages
+cp -Rf $HOME/temp/* .
+
+echo "Allow files with underscore https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/" > .nojekyll
+echo "[View live](https://${GH_USER}.github.io/${GH_REPO}/)" > README.md
+
+#add, commit and push files
+git add -f .
+git commit -m "Travis build $TRAVIS_BUILD_NUMBER"
+git push -fq origin gh-pages > /dev/null
+
+echo "Done updating gh-pages\n"
+
+else
+ echo "Skipped updating gh-pages, because build is not triggered from the master branch."
+fi;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
   "author": {
     "name": "Rich Tibbett"
   },
+  "scripts": {
+    "prebuild": "rm -rf ./dist",
+    "build": "grunt",
+    "start": "http-server './' -c-1 -o -p 8458",
+    "test": "grunt test",
+    "watch": "grunt watch"
+  },
   "keywords": [
     "full tilt",
     "fulltilt",
@@ -35,10 +42,11 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-concat": "~0.5.0",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-uglify": "~0.5.0",
-    "grunt-install-dependencies": "^0.2.0"
+    "grunt": "0.4.5",
+    "grunt-cli": "0.1.13",
+    "grunt-contrib-concat": "0.5.1",
+    "grunt-contrib-jshint": "0.12.0",
+    "grunt-contrib-uglify": "0.11.1",
+    "http-server": "0.8.5"
   }
 }


### PR DESCRIPTION
- feat(index): project and example index(.html) pages
- chore(package): update dependencies, define npm scripts, add local server
  
  `npm start` starts a simple HTTP server on localhost:8458 (T9 for tilt)
- chore(deploy): use travis to deploy to gh-pages (and like to it in project readme)
